### PR TITLE
Other updates for web actions

### DIFF
--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -87,7 +87,16 @@ jobs:
         needs: [build]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout Repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 2
+
+            - name: Debug Directory Structure
+              run: |
+                  pwd
+                  ls -la
+                  ls -la apps/
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -142,14 +151,9 @@ jobs:
             - name: Build Project Artifacts
               env:
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-              run: |
-                  cd apps/web
-                  vercel build --prod --token=${{ secrets.CP_VERCEL_TOKEN }}
+              run: vercel build apps/web --prod --token=${{ secrets.CP_VERCEL_TOKEN }}
 
-                  
             - name: Deploy Project Artifacts to Vercel
               env:
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-              run: |
-                  cd apps/web
-                  vercel deploy --prebuilt --prod --token=${{ secrets.CP_VERCEL_TOKEN }}
+              run: vercel deploy --prebuilt --prod --token=${{ secrets.CP_VERCEL_TOKEN }}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
🔥 Hotfix - No Linear issue number

## 📑 Description

This PR fixes the GitHub Actions deployment failure where the workflow couldn't find the `apps/web` directory. The issue was occurring during the Vercel build and deploy steps.

Changes made:
- [x] Enhanced repository checkout configuration with `fetch-depth: 2`
- [x] Added debug steps to verify directory structure during workflow execution
- [x] Fixed Vercel build and deploy commands to use project path instead of directory changes
- [x] Improved workflow readability with better step naming and organization

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

This hotfix addresses the following error:
```bash
/home/runner/work/_temp/35e11085-4a8b-43b1-877d-29ddb7a557e3.sh: line 1: cd: apps/web: No such file or directory