### PR TITLE
Being more specific about deploy working directory

### DIFF
--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -133,11 +133,11 @@ jobs:
               run: pnpm add -g vercel@latest
 
             - name: Link Project
-              working-directory: /home/runner/work/cloud-people/cloud-people
+              working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
               run: vercel link --confirm --token=${{ secrets.CP_VERCEL_TOKEN }}
 
             - name: Pull Vercel Environment Information
-              working-directory: /home/runner/work/cloud-people/cloud-people
+              working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
               run: vercel pull --yes --environment=production --token=${{ secrets.CP_VERCEL_TOKEN }}
 
             - name: Set Environment Variables
@@ -155,13 +155,13 @@ jobs:
                   echo SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" >> .env.production
 
             - name: Build Project Artifacts
-              working-directory: /home/runner/work/cloud-people/cloud-people
+              working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
               env:
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
               run: vercel build --prod --token=${{ secrets.CP_VERCEL_TOKEN }}
 
             - name: Deploy Project Artifacts to Vercel
-              working-directory: /home/runner/work/cloud-people/cloud-people
+              working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
               env:
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
               run: vercel deploy --prebuilt --prod --token=${{ secrets.CP_VERCEL_TOKEN }}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
🔥 Hotfix - No Linear issue number

## 📑 Description

This PR fixes the Next.js dependency detection issue in our GitHub Actions workflow. The Vercel build was failing because it couldn't find the Next.js package.

Changes made:
- [x] Updated all Vercel command working directories to `/home/runner/work/cloud-people/cloud-people/apps/web`
- [x] Fixed project linking context for Vercel CLI
- [x] Ensured build and deploy steps run in the correct package context

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

This hotfix addresses the following error:
```bash
Warning: Could not identify Next.js version, ensure it is defined as a project dependency.
Error: No Next.js version could be detected in your project. Make sure `"next"` is installed in "dependencies" or "devDependencies"

The changes ensure that:

Vercel commands run from the web app directory where Next.js is installed
Project linking and environment setup occur in the correct context
Build and deploy steps have access to all necessary dependencies
Modified commands to run from web app directory:

vercel link
vercel pull
vercel build
vercel deploy
No breaking changes were introduced, and all existing environment variables and secrets remain unchanged. This fix maintains our monorepo structure while ensuring proper dependency resolution during the build process.