### PR TITLE
fixes the Vercel deployment error related to styled-jsx module resolution

### DIFF
--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -106,6 +106,7 @@ jobs:
             - name: Configure pnpm
               run: |
                   echo "node-linker=hoisted" > .npmrc
+                  echo "shamefully-hoist=true" >> .npmrc
                   cat .npmrc
 
             - name: Get pnpm store directory
@@ -128,6 +129,12 @@ jobs:
                   echo "Verifying Next.js installation..."
                   ls -la apps/web/node_modules/next || echo "Next.js not found in web app node_modules"
                   ls -la node_modules/next || echo "Next.js not found in root node_modules"
+
+            - name: Install styled-jsx
+              working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
+              run: |
+                  echo "Installing styled-jsx explicitly..."
+                  pnpm add styled-jsx@latest
 
             - name: Install Vercel CLI
               run: pnpm add -g vercel@latest
@@ -165,6 +172,8 @@ jobs:
                   echo "Node modules structure:"
                   ls -la node_modules/next || echo "Next.js not found in web app node_modules"
                   ls -la ../../node_modules/next || echo "Next.js not found in root node_modules"
+                  echo "Verifying styled-jsx installation:"
+                  ls -la node_modules/styled-jsx || echo "styled-jsx not found in web app node_modules"
                   echo "Running Vercel build..."
                   vercel build --prod --token=${{ secrets.CP_VERCEL_TOKEN }}
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
🐛 Bug Fix - No Linear issue number

## 📑 Description

This PR fixes the Vercel deployment error related to styled-jsx module resolution in our monorepo setup. The error was occurring because styled-jsx wasn't properly hoisted in the pnpm dependency tree.

Changes made:
- [x] Added `shamefully-hoist=true` to pnpm configuration
- [x] Added explicit installation of styled-jsx
- [x] Enhanced dependency verification steps

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

### Error Being Fixed
```bash
Error: ENOENT: no such file or directory, lstat '/node_modules/styled-jsx/index.js'
Key Changes
Enhanced pnpm Configuration:
diff
CopyInsert
echo "node-linker=hoisted" > .npmrc
+ echo "shamefully-hoist=true" >> .npmrc
This ensures dependencies are properly hoisted and accessible to Vercel's build process.
Added Explicit styled-jsx Installation:
yaml
CopyInsert
- name: Install styled-jsx
  working-directory: /home/runner/work/cloud-people/cloud-people/apps/web
  run: |
    echo "Installing styled-jsx explicitly..."
    pnpm add styled-jsx@latest
Added Dependency Verification:
yaml
CopyInsert
echo "Verifying styled-jsx installation:"
ls -la node_modules/styled-jsx || echo "styled-jsx not found in web app node_modules"
Technical Details
The issue stems from pnpm's strict dependency management in monorepos, which can sometimes conflict with Vercel's expectations. Our solution:

Uses shamefully-hoist=true to make dependencies more accessible
Explicitly installs styled-jsx to ensure its presence
Adds verification steps to catch potential issues early
References
[Vercel Monorepo Documentation](https://vercel.com/docs/monorepos)
[pnpm Dependency Hoisting](https://pnpm.io/npmrc#shamefully-hoist)
[Next.js styled-jsx](https://nextjs.org/docs/pages/building-your-application/styling/css-in-js)
No breaking changes were introduced. These changes maintain the integrity of our monorepo structure while ensuring compatibility with Vercel's build process.