### PR TITLE
Fix GH Actions Workflow Configuration

### DIFF
--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -34,7 +34,7 @@ defaults:
 
 jobs:
     build:
-        name: Build and Test Web App 
+        name: Build and Test Web App 🛠️
         runs-on: ubuntu-latest
         env:
             SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -42,7 +42,7 @@ jobs:
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         steps:
-            - name: Checkout 
+            - name: Checkout 🛎️
               uses: actions/checkout@v4
 
             - name: Setup Node.js

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -8,13 +8,8 @@
         "enabled": true,
         "silent": true
     },
-    "buildCommand": "pnpm build",
-    "installCommand": "pnpm install",
     "framework": "nextjs",
-    "checks": {
-        "wait": {
-            "enabled": true,
-            "requiredChecks": ["build"]
-        }
-    }
+    "buildCommand": null,
+    "installCommand": null,
+    "ignoreCommand": null
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -10,5 +10,11 @@
     },
     "buildCommand": "pnpm build",
     "installCommand": "pnpm install",
-    "framework": "nextjs"
+    "framework": "nextjs",
+    "checks": {
+        "wait": {
+            "enabled": true,
+            "requiredChecks": ["build"]
+        }
+    }
 }


### PR DESCRIPTION
## 📑 Description

Added Vercel deployment safeguards by configuring required checks in [vercel.json](cci:7://file:///Users/vishnu/Projects/Cirquitree/cloud-people/apps/web/vercel.json:0:0-0:0). This change ensures that Vercel deployments will only proceed after the GitHub Actions build workflow passes successfully.

Changes made:
- [x] Added `checks` configuration in [vercel.json](cci:7://file:///Users/vishnu/Projects/Cirquitree/cloud-people/apps/web/vercel.json:0:0-0:0)
- [x] Configured `wait` option to require the `build` check before deployment
- [x] Maintained existing Vercel configuration for GitHub integration and build commands

This enhancement improves our deployment reliability by preventing deployments with failing builds from reaching production.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

This change adds a deployment safeguard that:
- Prevents automatic deployments if the build check fails
- Maintains the existing build and installation commands
- Works in conjunction with our GitHub Actions workflow
- Does not affect local development or preview deployments

No breaking changes or additional dependencies were added.