### PR TITLE
Added llm api keys to gh actions

### DIFF
--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -6,6 +6,8 @@ env:
     SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
     NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 on:
     push:
@@ -53,6 +55,8 @@ jobs:
             SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+            OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+            ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         steps:
             - name: Checkout 🛎️
               uses: actions/checkout@v4


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Hotfix: Add Missing Environment Variables to GitHub Actions

## 📑 Description

This PR adds missing environment variables to the GitHub Actions workflow for proper CI/CD functionality:

- [x] Add OPENAI_API_KEY to workflow environment
- [x] Add ANTHROPIC_API_KEY to workflow environment
- [x] Add variables to both global and build job scopes

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

### Changes Made
- Added OPENAI_API_KEY and ANTHROPIC_API_KEY to global env section
- Added same variables to build job env section
- Variables reference GitHub secrets that must be configured:
  - OPENAI_API_KEY
  - ANTHROPIC_API_KEY

### Action Required
Repository administrators need to add the following secrets in GitHub repository settings:
- OPENAI_API_KEY
- ANTHROPIC_API_KEY