### PR TITLE
Mw/dev/agent chaining

### DIFF
--- a/apps/web/src/components/agents/layouts/assistance-agent-layout.tsx
+++ b/apps/web/src/components/agents/layouts/assistance-agent-layout.tsx
@@ -15,6 +15,8 @@ export const AssistanceAgentLayout = ({ agentId, agentData, onAssistanceRequest 
     const data = agentData || getAgentData(agentId);
     const agentState = getAgentState(agentId);
 
+    console.log(`[AssistanceLayout ${agentId}] Rendering. State: ${agentState?.state}, ErrorMsg: ${data?.errorMessage}, AssistMsg: ${data?.assistanceMessage}`);
+
     return (
         <div className="assistance-card" onClick={onAssistanceRequest}>
             {agentState?.state === AgentState.Assistance && (

--- a/apps/web/src/contexts/mock-user-context.tsx
+++ b/apps/web/src/contexts/mock-user-context.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { createContext } from 'react';
+import { ReactNode } from 'react';
 import { useContext } from 'react';
 import { useState } from 'react';
 import { useEffect } from 'react';

--- a/apps/web/src/hooks/use-agent.ts
+++ b/apps/web/src/hooks/use-agent.ts
@@ -122,7 +122,7 @@ export const useAgent = (agentData: AgentData, onStatusChange?: (status: AgentSt
             console.log(`[useAgent] executeTask finished for agent ${agentData.id}.`);
         }
 
-    }, [agentData, isProcessing, getAgentState, updateAgentState, setAgentResult, setAgentData, getAgentData, onStatusChange]);
+    }, [agentData, isProcessing, onStatusChange]);
 
     const pauseAgentExecution = useCallback(async (): Promise<boolean> => {
         if (!agentData?.id) {
@@ -172,7 +172,7 @@ export const useAgent = (agentData: AgentData, onStatusChange?: (status: AgentSt
             return false;
         }
         // Depend on agentData, store functions, and callbacks
-    }, [agentData, getAgentState, updateAgentState, setAgentData, getAgentData, onStatusChange, setError]);
+    }, [agentData, onStatusChange, setError]);
 
     return {
         isProcessing,

--- a/apps/web/src/hooks/use-agent.ts
+++ b/apps/web/src/hooks/use-agent.ts
@@ -122,7 +122,7 @@ export const useAgent = (agentData: AgentData, onStatusChange?: (status: AgentSt
             console.log(`[useAgent] executeTask finished for agent ${agentData.id}.`);
         }
 
-    }, [agentData, isProcessing, onStatusChange]);
+    }, [agentData, isProcessing, onStatusChange, getAgentData, setAgentData, setAgentResult, updateAgentState]);
 
     const pauseAgentExecution = useCallback(async (): Promise<boolean> => {
         if (!agentData?.id) {
@@ -172,7 +172,7 @@ export const useAgent = (agentData: AgentData, onStatusChange?: (status: AgentSt
             return false;
         }
         // Depend on agentData, store functions, and callbacks
-    }, [agentData, onStatusChange, setError]);
+    }, [agentData, onStatusChange, setError, getAgentData, getAgentState, setAgentData, updateAgentState]);
 
     return {
         isProcessing,

--- a/apps/web/src/lib/service-providers/agent-service.ts
+++ b/apps/web/src/lib/service-providers/agent-service.ts
@@ -14,7 +14,7 @@ import { authCheck } from '@lib/actions/authentication-actions';
 import { connectToDB } from '@lib/utils';
 import type { QueryConfig } from '@app-types/api';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { createClient } from '@lib/supabase/client';
+import { createClient } from '@supabase/supabase-js'; // CORRECT: For server-side usage with service key
 
 // Define the interface for our agent service
 export interface AgentService {

--- a/apps/web/src/stores/workflow/constants.ts
+++ b/apps/web/src/stores/workflow/constants.ts
@@ -5,6 +5,7 @@ import type { GraphState } from '@app-types/workflow';
 import { InitialStateNodeData } from '@app-types/workflow';
 import { NodeType } from '@app-types/workflow/node-types';
 import { useThemeStore } from '@stores/theme-store';
+import { initialWorkflowContext } from './features/workflow-context';
 
 export const getInitialStateNodes = (): Node<InitialStateNodeData>[] => {
     const isDarkMode = useThemeStore.getState().isDarkMode;
@@ -76,7 +77,8 @@ export const initialStateNodes = getInitialStateNodes();
 export const getInitialState = (): GraphState => ({
     nodes: getInitialStateNodes(),
     edges: [],
-    workflowExecution: null
+    workflowExecution: null,
+    workflowContext: initialWorkflowContext
 });
 
 export const initialState: GraphState = getInitialState();

--- a/apps/web/src/stores/workflow/features/workflow-context.ts
+++ b/apps/web/src/stores/workflow/features/workflow-context.ts
@@ -56,14 +56,6 @@ export const createWorkflowContext = (
       }),
 
     /**
-     * Gets the entire workflow context with memoization
-     * @returns The workflow context
-     */
-    getWorkflowContext: () => {
-      return useShallow((state: GraphState) => state.workflowContext);
-    },
-
-    /**
      * Gets a specific agent's data from the workflow context
      * @param agentId - The ID of the agent whose data to retrieve
      * @returns The agent's result or null if not found


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please ensure that your pull request is focused on a single type of change (e.g., feature, bugfix, etc.) and keep it concise. Consider splitting large changes into multiple PRs.
-->

## 🔗 Linked Issues

<!-- If this pull request resolves an issue, mention the Linear issue ID here -->

Hotfix - No specific Linear issue.

## 📄 Description

<!-- Provide a brief description of the changes introduced by this PR -->

This hotfix addresses intermittent "Task terminated due to inactivity" errors occurring in the `browser-service`. It introduces a heartbeat mechanism to prevent the premature cleanup of long-running agent tasks, particularly when they experience delays (e.g., due to API rate limits).

*(Optional: Add a sentence about the build error fix if you know what it was, e.g., "It also includes a fix for a recent build error related to [specific component/dependency].")*

## 📋 Changes

<!-- List your changes using a markdown checklist -->

-   [x] **[services/browser-service/main.py](cci:7://file:///Users/archimedes/Projects/cloud-people/services/browser-service/main.py:0:0-0:0)**: Implemented an `asyncio` heartbeat task within [run_task](cci:1://file:///Users/archimedes/Projects/cloud-people/services/browser-service/main.py:393:0-534:76) to periodically update the `last_activity` timestamp in the task's metadata while `agent_adapter.execute_task` is running.
-   [x] services/browser-service/main.py: Ensured the heartbeat task is properly cancelled in the `finally` block of run_task of main.py.
-   [x] **services/browser-service/main.py**: Added necessary imports (`asyncio`, `datetime`).
-   [ ] *(Optional: Add checklist item for the build error fix)*

## ✅ Checks

<!-- Ensure your PR passes all necessary checks -->

-   [x] Adheres to the project's code style
-   [ ] Documentation updated if necessary *(N/A for this change)*
-   [ ] All tests pass successfully *(Assuming tests will be run)*
-   [ ] Linked Linear issue moves to 'In Progress' when PR is drafted and 'Done' when merged *(N/A for hotfix)*

## 🖼️ Screenshots (if applicable)

<!-- Add screenshots to illustrate new features or changes -->

N/A

## ℹ️ Additional Information

<!-- Provide any additional information such as breaking changes, dependencies added, or context for reviewers -->

The root cause of the inactivity error was identified as the `periodic_task_cleanup` function marking tasks as failed because the `last_activity` timestamp wasn't being updated during the potentially long-running `agent_adapter.execute_task` call. Since modifying the underlying `browser-use` library's `agent.run()` method was not feasible, a heartbeat task was added to the calling function `run_task` to keep the timestamp fresh every 30 seconds. This ensures the cleanup function doesn't incorrectly identify active tasks as stale.